### PR TITLE
Fixed capitalization in arduino LW20.cpp

### DIFF
--- a/Arduino/source/LW20.cpp
+++ b/Arduino/source/LW20.cpp
@@ -1,4 +1,4 @@
-#include "lw20.h"
+#include "LW20.h"
 #define LW20_API_IMPLEMENTATION
 #include "lw20api.h"
 


### PR DESCRIPTION
LW20.cpp was not including LW20.h, because it is case sensitive and was written as lw20.h.